### PR TITLE
Bump Rust Docker base image to 1.96

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM rust:1.85-alpine AS builder
+FROM rust:1.96-alpine AS builder
 WORKDIR /usr/src/
 RUN apk add pkgconfig openssl-dev libc-dev
 


### PR DESCRIPTION
Mechanical bump of the Dockerfile `FROM rust:1.X` base image to `rust:1.96`. No source changes; toolchain bump only.

Part of kj800x/homelab#3.